### PR TITLE
Add Citrus integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+target
+.project
+.classpath
+.settings
+.idea
+.DS_Store
+*.iml
+*.ipr
+*.iws
+.metadata
+bin
+.codepro
+.pmd
+.externalToolBuilders/
+maven-eclipse.xml
+
+#Auto generated Avro and Protobuf resources
+*.proto
+*.avsc
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Download Red Hat's version of Kafka from [here](https://access.redhat.com/jbossn
   docker run -it -p 8080:8080 -e "KAFKA_BOOTSTRAP_SERVERS=host.docker.internal:9092" -e "APPLICATION_ID=myregistry" apicurio/apicurio-registry-streams:latest
   ```
 
-
 ## Upload Schema to Apicurio Registry
 
 In your browser http://localhost:8080/ui/artifacts upload the schema for both topics.
@@ -95,7 +94,117 @@ And you should have three Camel applications running
 
 And you should have three Camel applications running
 
-### Request to transfer
+### Test the applications
+
+Now that we have all parts of the application up and running we can test the message processing by sending a transfer request
+and verifying its outcome in the MongoDB.
+  
+This works on both options, you can issue and verify a transfer request by running the automated [Citrus](https://citrusframework.org) 
+integration test in the folder *citrus-test*:
+
+```
+mvn verify
+```
+
+Here is a sample output of the automated test:
+
+```
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running demo.camel.ProcessTransferIT
+INFO |main|LoggingReporter - 
+INFO |main|LoggingReporter - ------------------------------------------------------------------------
+INFO |main|LoggingReporter -        .__  __                       
+INFO |main|LoggingReporter -   ____ |__|/  |________ __ __  ______
+INFO |main|LoggingReporter - _/ ___\|  \   __\_  __ \  |  \/  ___/
+INFO |main|LoggingReporter - \  \___|  ||  |  |  | \/  |  /\___ \ 
+INFO |main|LoggingReporter -  \___  >__||__|  |__|  |____//____  >
+INFO |main|LoggingReporter -      \/                           \/
+INFO |main|LoggingReporter - 
+INFO |main|LoggingReporter - C I T R U S  T E S T S  3.0.0-M2
+INFO |main|LoggingReporter - 
+INFO |main|LoggingReporter - ------------------------------------------------------------------------
+INFO |main|LoggingReporter - 
+INFO |main|LoggingReporter - 
+INFO |main|LoggingReporter - BEFORE TEST SUITE: SUCCESS
+INFO |main|LoggingReporter - ------------------------------------------------------------------------
+INFO |main|LoggingReporter - 
+WARN |main|TypeConverter - Missing type converter for name 'default' - using default type converter
+DEBUG|main|Message_OUT - POST http://localhost:8081/transfer
+Accept:text/plain, application/json, application/*+json, */*
+Content-Type:application/json
+Content-Length:201
+
+{
+  "transactionid": "A018562",
+  "transactiontype": "NORMALADD",
+  "sender": {
+    "username": "Christina",
+    "userid": "chrissy"
+  },
+  "currency": "USD",
+  "amt": 100.0,
+  "receiverid": "Citrus"
+}
+DEBUG|main|Message_IN - HTTP/1.1 200 OK OK
+content-length:30
+Accept:text/plain, application/json, application/*+json, */*
+Accept-Encoding:gzip,deflate
+org.apache.kafka.clients.producer.RecordMetadata:webtrans-0@17
+sender:chrissy
+User-Agent:Apache-HttpClient/4.5.12 (Java/1.8.0_192)
+content-type:application/octet-stream
+connection:Keep-Alive
+
+Transaction from chrissy sent.
+INFO |main|LoggingReporter - 
+INFO |main|LoggingReporter - TEST SUCCESS ProcessTransferIT.shouldTransfer (demo.camel)
+INFO |main|LoggingReporter - ------------------------------------------------------------------------
+INFO |main|LoggingReporter - 
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.365 s - in demo.camel.ProcessTransferIT
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - ------------------------------------------------------------------------
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - AFTER TEST SUITE: SUCCESS
+INFO |Thread-1|LoggingReporter - ------------------------------------------------------------------------
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - ------------------------------------------------------------------------
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - CITRUS TEST RESULTS
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter -  ProcessTransferIT.shouldTransfer ............................... SUCCESS
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - TOTAL:	1
+INFO |Thread-1|LoggingReporter - FAILED:	0 (0.0%)
+INFO |Thread-1|LoggingReporter - SUCCESS:	1 (100.0%)
+INFO |Thread-1|LoggingReporter - 
+INFO |Thread-1|LoggingReporter - ------------------------------------------------------------------------
+[INFO] 
+[INFO] Results:
+[INFO] 
+[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+[INFO] 
+[INFO] 
+[INFO] --- maven-failsafe-plugin:2.22.2:verify (integration-tests) @ citrus-test ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  8.270 s
+[INFO] Finished at: 2020-11-30T10:48:26+01:00
+[INFO] ------------------------------------------------------------------------
+```
+
+The automated Citrus test will run these steps in order to verify the applications:
+
+- Generate a new transaction id
+- Issue the transfer request via Http REST
+- Verify the transaction entries in the MongoDB for both transaction sender and receiver 
+
+#### Manual testing
+
+You can also issue a new transfer request and verify its outcome in the MongoDB manually.
 
 This works on both options, you can now issue a transfer request:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the demo, we have one topic that stores the Transfer Request events, and one 
 
 #### Kafka (AMQ Streams)
 - First you need a Kafka Streaming cluster to store the events.
-Download Red Hat's version of Kafka from [here](https://developers.redhat.com/download-manager/file/amq-streams-1.3.0-ocp-install-examples.zip)
+Download Red Hat's version of Kafka from [here](https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=jboss.amq.streams)
 - Unzip the file and set the $KAFKA_HOME to the unzip directory.
 - Start up the Kafka cluster's broker and zookeeper locally. Also create all the topics needed later.
    `./demo_setup.sh`
@@ -66,10 +66,13 @@ Start up the 3 applications that are publishing and subscribing events from the 
 ##### OPTION A: Running Camel on Java Main and using the Apicurio Registry Libraries for Serde before sending to Kafka Topics.
 
 - Start REST to protobuf, in a new terminal, go to folder *camel-demo-restprotobuf*
-`
+
+  run `mvn compile exec:java`
+  
 - Start protobuf to avro, in a new terminal, go to folder *camel-demo-protobuf2avro*
 
   run `mvn compile exec:java`
+
 - Start avro to json (MongoDB), in a new terminal, go to folder *camel-demo-avro2mongo*
 
   run `mvn compile exec:java`
@@ -81,9 +84,11 @@ And you should have three Camel applications running
 - Start REST to protobuf, in a new terminal, go to folder *camel-quarkus-restprotobuf*
 
   run `mvn compile quarkus:dev`
+  
 - Start protobuf to avro, in a new terminal, go to folder *camel-quarkus-protobuf2avro*
 
   run `mvn compile quarkus:dev`
+  
 - Start avro to json (MongoDB), in a new terminal, go to folder *camel-quarkus-avro2mongo*
 
   run `mvn compile quarkus:dev`
@@ -111,7 +116,7 @@ curl -XPOST -H "Content-type: application/json" -d '{
 
 You will be able to see the result in the MongoDB
 
-In a new broswer, connect to the MongoDB container
+In a new terminal, connect to the MongoDB container
 
 ```
 docker exec -it mongodb bash
@@ -131,7 +136,6 @@ You should be able to see two records appear in the transaction table.
 { "_id" : ObjectId("5fa437d052afae2d0c6c8246"), "userid" : "chrissy", "transactionid" : "A010383", "transactiontype" : "SUB", "currency" : "USD", "amt" : "100.0" }
 { "_id" : ObjectId("5fa437d052afae2d0c6c824a"), "userid" : "Franz", "transactionid" : "A010383", "transactiontype" : "ADD", "currency" : "USD", "amt" : "100.0" }
 ```
-
 
 ### Resources
 Read more on how to implement them in the *Contract First* way with the schema from Apicurio Registry.

--- a/camel-demo-avro2mongo/pom.xml
+++ b/camel-demo-avro2mongo/pom.xml
@@ -7,7 +7,7 @@
   <groupId>demo.camel</groupId>
   <artifactId>camel-avro2mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>1.0.0</version>
 
   <name>Schema Camel Route</name>
 
@@ -41,8 +41,8 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
   </dependency>
-  
-  
+
+
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-main</artifactId>
@@ -51,12 +51,12 @@
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-avro</artifactId>
-  </dependency> 
-  
+  </dependency>
+
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-jackson</artifactId>
-  </dependency> 
+  </dependency>
   <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
@@ -196,7 +196,7 @@
         </executions>
       </plugin>
 
-     
+
 
     </plugins>
     <extensions>

--- a/camel-demo-avro2mongo/pom.xml
+++ b/camel-demo-avro2mongo/pom.xml
@@ -190,7 +190,7 @@
             </goals>
             <configuration>
               <sourceDirectory>${project.basedir}/src/main/resources</sourceDirectory>
-              <outputDirectory>${project.basedir}/src/main/java</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/camel-demo-avro2mongo/pom.xml
+++ b/camel-demo-avro2mongo/pom.xml
@@ -60,7 +60,7 @@
   <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>2.11.0.redhat-00001</version>
+    <version>2.11.3</version>
   </dependency>
 
   <!--<dependency>

--- a/camel-demo-avro2mongo/pom.xml
+++ b/camel-demo-avro2mongo/pom.xml
@@ -84,11 +84,6 @@
   </dependency>
 
 
-  <dependency>
-    <groupId>org.apache.camel</groupId>
-    <artifactId>camel-avro</artifactId>
-  </dependency>
-
   <!-- logging -->
   <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/camel-demo-protobuf2avro/pom.xml
+++ b/camel-demo-protobuf2avro/pom.xml
@@ -173,7 +173,7 @@
             </goals>
             <configuration>
               <sourceDirectory>${project.basedir}/src/main/resources</sourceDirectory>
-              <outputDirectory>${project.basedir}/src/main/java</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -193,7 +193,7 @@
             </goals>
             <configuration>
               <protocArtifact>com.google.protobuf:protoc:${protobuf-version}:exe:${os.detected.classifier}</protocArtifact>
-              <outputDirectory>${project.basedir}/src/main/java</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
               <protoSourceRoot>${project.basedir}/src/main/resources</protoSourceRoot>
               <clearOutputDirectory>false</clearOutputDirectory>
             </configuration>

--- a/camel-demo-protobuf2avro/pom.xml
+++ b/camel-demo-protobuf2avro/pom.xml
@@ -7,7 +7,7 @@
   <groupId>demo.camel</groupId>
   <artifactId>camel-profobuf2avro-producer</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>1.0.0</version>
 
   <name>Schema Camel Route</name>
 
@@ -45,21 +45,21 @@
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-main</artifactId>
   </dependency>
-  
+
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-protobuf</artifactId>
-  </dependency>  
+  </dependency>
 
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-jackson</artifactId>
-  </dependency>  
+  </dependency>
 
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-avro</artifactId>
-  </dependency>  
+  </dependency>
 
 
   <dependency>

--- a/camel-demo-restprotobuf/pom.xml
+++ b/camel-demo-restprotobuf/pom.xml
@@ -7,7 +7,7 @@
   <groupId>demo.camel</groupId>
   <artifactId>camel-profobufkaka-producer</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>1.0.0</version>
 
   <name>Schema Camel Route</name>
 
@@ -46,18 +46,18 @@
     <artifactId>camel-main</artifactId>
   </dependency>
 
-  
+
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-netty-http</artifactId>
   </dependency>
 
-  
+
 
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-protobuf</artifactId>
-  </dependency>  
+  </dependency>
   <dependency>
     <groupId>org.glassfish.jersey.core</groupId>
     <artifactId>jersey-common</artifactId>
@@ -67,13 +67,13 @@
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-jackson</artifactId>
-  </dependency>  
+  </dependency>
 
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-jsonpath</artifactId>
-  </dependency>  
-  
+  </dependency>
+
   <dependency>
     <groupId>org.apache.camel</groupId>
     <artifactId>camel-kafka</artifactId>
@@ -107,7 +107,7 @@
     <artifactId>apicurio-registry-utils-converter</artifactId>
     <version>${registry.version}</version>
   </dependency>
-  
+
 </dependencies>
 
 

--- a/camel-demo-restprotobuf/pom.xml
+++ b/camel-demo-restprotobuf/pom.xml
@@ -179,7 +179,7 @@
             </goals>
             <configuration>
               <protocArtifact>com.google.protobuf:protoc:${protobuf-version}:exe:${os.detected.classifier}</protocArtifact>
-              <outputDirectory>${project.basedir}/src/main/java</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
               <protoSourceRoot>${project.basedir}/src/main/resources</protoSourceRoot>
               <clearOutputDirectory>false</clearOutputDirectory>
             </configuration>

--- a/citrus-test/pom.xml
+++ b/citrus-test/pom.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>demo.camel</groupId>
+  <artifactId>citrus-test</artifactId>
+  <version>1.0.0</version>
+  <name>Camel :: Demo :: Citrus Tests</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <apache.camel.version>3.5.0</apache.camel.version>
+    <citrus.version>3.0.0-M2</citrus.version>
+    <slf4j.version>1.7.30</slf4j.version>
+    <log4j2.version>2.13.3</log4j2.version>
+    <registry.version>1.3.1.Final</registry.version>
+    <avro-version>1.9.1</avro-version>
+    <protobuf-version>3.13.0</protobuf-version>
+    <assertj.version>3.18.1</assertj.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-bom</artifactId>
+        <version>${citrus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Citrus -->
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-camel</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-text</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-mongodb</artifactId>
+      <version>${apache.camel.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring</artifactId>
+      <version>${apache.camel.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf-version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+          <workingDirectory>${project.build.directory}</workingDirectory>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.2</version>
+        <executions>
+          <execution>
+            <id>integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!--Registry download-->
+      <plugin>
+        <groupId>io.apicurio</groupId>
+        <artifactId>apicurio-registry-maven-plugin</artifactId>
+        <version>${registry.version}</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>download</goal>
+            </goals>
+            <configuration>
+              <registryUrl>http://localhost:8080/api</registryUrl>
+              <ids>
+                <param1>demo-avro</param1>
+                <param1>demo-protobuf</param1>
+              </ids>
+              <outputDirectory>${project.basedir}/src/test/resources</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!--AVRO Generator-->
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>1.8.1</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>schema</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/test/resources</sourceDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!--PROTOBUF Generator-->
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <protocArtifact>com.google.protobuf:protoc:${protobuf-version}:exe:${os.detected.classifier}</protocArtifact>
+              <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+              <protoSourceRoot>${project.basedir}/src/test/resources</protoSourceRoot>
+              <clearOutputDirectory>false</clearOutputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+  </build>
+
+</project>

--- a/citrus-test/src/test/java/demo/camel/ProcessTransferIT.java
+++ b/citrus-test/src/test/java/demo/camel/ProcessTransferIT.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo.camel;
+
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.http.client.HttpClient;
+import com.consol.citrus.junit.JUnit4CitrusSupport;
+import com.consol.citrus.message.MessageType;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import demo.camel.config.EndpointConfig;
+import org.apache.camel.component.mongodb.MongoDbConstants;
+import org.assertj.core.api.Assertions;
+import org.bson.Document;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+
+import static com.consol.citrus.actions.CreateVariablesAction.Builder.createVariable;
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+import static com.consol.citrus.container.RepeatOnErrorUntilTrue.Builder.repeatOnError;
+import static com.consol.citrus.http.actions.HttpActionBuilder.http;
+
+@ContextConfiguration(classes = EndpointConfig.class)
+public class ProcessTransferIT extends JUnit4CitrusSupport {
+
+    @Autowired
+    private HttpClient transactionClient;
+
+    @Test
+    @CitrusTest
+    public void shouldTransfer() throws InvalidProtocolBufferException {
+        given(createVariable("id", "A0citrus:randomNumber(5)"));
+        given(createVariable("userId", "chrissy"));
+        given(createVariable("receiverId", "Citrus"));
+
+        // when send transaction
+        when(http().client(transactionClient)
+                .send()
+                .post("/transfer")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .payload(JsonFormat.printer().print(TransactionProtos.Transaction
+                        .newBuilder()
+                        .setTransactionid("${id}")
+                        .setTransactiontype("NORMALADD")
+                        .setSender(TransactionProtos.Transaction.User.newBuilder()
+                                .setUsername("Christina")
+                                .setUserid("${userId}")
+                                .build())
+                        .setReceiverid("${receiverId}")
+                        .setCurrency("USD")
+                        .setAmt(100.00D))));
+
+        then(http().client(transactionClient)
+                .receive()
+                .response(HttpStatus.OK)
+                .payload("Transaction from ${userId} sent."));
+
+        // then wait for and verify entries in MongoDb
+        String mongoDbTransactionsUri = "camel:sync:mongodb:mongoClient?database=example&collection=transaction";
+        then(repeatOnError()
+                .condition((index, context) -> index > 10)
+                .actions(
+                    send(mongoDbTransactionsUri)
+                        .header(MongoDbConstants.OPERATION_HEADER, "count")
+                        .payload("{\"transactionid\": \"${id}\"}"),
+                    receive(mongoDbTransactionsUri)
+                            .messageType(MessageType.PLAINTEXT)
+                            .payload("2")
+                )
+        );
+
+        // then verify transaction sender
+        then(send(mongoDbTransactionsUri)
+                .header(MongoDbConstants.OPERATION_HEADER, "findOneByQuery")
+                .payload("{" +
+                    "\"transactionid\": \"${id}\"," +
+                    "\"userid\": \"${userId}\"" +
+                "}")
+        );
+
+        then(receive(mongoDbTransactionsUri)
+                .validationCallback((message, context) -> {
+                    Document sender = message.getPayload(Document.class);
+                    Assertions.assertThat(sender.get("transactiontype")).isEqualTo("SUB");
+                    Assertions.assertThat(sender.get("amt")).isEqualTo("100.0");
+                    Assertions.assertThat(sender.get("currency")).isEqualTo("USD");
+                })
+        );
+
+        // then verify transaction receiver
+        then(send(mongoDbTransactionsUri)
+                .header(MongoDbConstants.OPERATION_HEADER, "findOneByQuery")
+                .payload("{" +
+                    "\"transactionid\": \"${id}\"," +
+                    "\"userid\": \"${receiverId}\"" +
+                "}")
+        );
+
+        then(receive(mongoDbTransactionsUri)
+                .validationCallback((message, context) -> {
+                    Document receiver = message.getPayload(Document.class);
+                    Assertions.assertThat(receiver.get("transactiontype")).isEqualTo("ADD");
+                    Assertions.assertThat(receiver.get("amt")).isEqualTo("100.0");
+                    Assertions.assertThat(receiver.get("currency")).isEqualTo("USD");
+                })
+        );
+    }
+}

--- a/citrus-test/src/test/java/demo/camel/config/EndpointConfig.java
+++ b/citrus-test/src/test/java/demo/camel/config/EndpointConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package demo.camel.config;
+
+import com.consol.citrus.http.client.HttpClient;
+import com.consol.citrus.http.client.HttpClientBuilder;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.apache.camel.CamelContext;
+import org.apache.camel.spring.SpringCamelContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EndpointConfig {
+
+    private static final int TRANSACTION_SERVICE_PORT = 8081;
+    private static final int MONGO_DB_PORT = 27017;
+
+    @Bean
+    public HttpClient transactionClient() {
+        return new HttpClientBuilder()
+                .requestUrl(String.format("http://localhost:%s", TRANSACTION_SERVICE_PORT))
+            .build();
+    }
+
+    @Bean
+    public CamelContext camelContext() {
+        return new SpringCamelContext();
+    }
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(String.format("mongodb://localhost:%s", MONGO_DB_PORT));
+    }
+}

--- a/citrus-test/src/test/resources/citrus-application.properties
+++ b/citrus-test/src/test/resources/citrus-application.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+citrus.default.message.type=JSON

--- a/citrus-test/src/test/resources/log4j2-test.xml
+++ b/citrus-test/src/test/resources/log4j2-test.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%t|%c{1} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+
+    <Logger name="com.consol.citrus.report.LoggingReporter" additivity="false" level="INFO">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="com.consol.citrus" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="Logger.Message_IN" additivity="false" level="DEBUG">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="Logger.Message_OUT" additivity="false" level="DEBUG">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.springframework" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.eclipse" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.apache" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
This PR adds an automated Citrus integration test in order to leverage Contract Driven Testing concepts.

The Citrus test is located in a separate module [citrus-test]() and makes use of the APICurio registry to load Avro and Protobuf schemas before the test. The automated test uses the downloaded schemas and performs following steps

- Generate a new transaction id
- Issue transfer request (Protobuf Transaction model) via Http REST endpoint
- Wait for and verify entries in the MongoDB for both transaction sender and receiver

The test sends a transfer request to the Http REST endpoint using a Protobuf Transaction model as a payload. This request triggers the message processing on all participant components so we can verify the resulting MongoDB entries for the given transaction.

MongoDB is not explicitly supported by Citrus out of the box. This is why the test makes use of the `citrus-camel` and `camel-mongodb` components to verify the entries in MongoDB. This is a good example of how Citrus can use Apache Camel components to connect with technologies such as MongoDB that are not supported by Citrus itself.

The test actively waits for the entries to be present in the MongoDB database in order to verify them. This is done with a `repeatOnError` action container provided from Citrus. The repeatOnError will poll for the entries max. 10 times with a default delay of 1000 milliseconds between the attempts. This makes sure that the test waits for the application components to process everything and that the entries are present in the MongoDB.

The PR also has some general improvements

- Add .gitignore file
- Use same project version `1.0.0` everywhere
- Use default Maven generated sources output directory
- Fix duplicate camel-avro dependency in Maven POMs
- Fix unreachable jackson-databind version
- Fix Kafka download link in README